### PR TITLE
applied changes to suport cirque in docker

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -28,9 +28,11 @@ jobs:
             image: connectedhomeip/chip-build-cirque:0.4.9
             volumes:
                 - "/tmp/cirque_test_output:/tmp/cirque_test_output"
+                - "/dev/pts:/dev/pts"
 
         env:
             LOG_DIR: /tmp/cirque_test_output/
+            privileged: true
             CLEANUP_DOCKER_FOR_CI: 1
 
         steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -75,7 +75,7 @@
 	url = https://github.com/openweave/cirque.git
 	branch = master
 	ignore = dirty
-	commit = bc42efe2e0e8f4e0eed7bd08a51e046943a11b98
+	commit = 905112cbeeda504223209798ec23e3754ce43fca
 [submodule "happy"]
 	path = third_party/happy/repo
 	url = https://github.com/openweave/happy.git

--- a/integrations/docker/images/chip-build-cirque/Dockerfile
+++ b/integrations/docker/images/chip-build-cirque/Dockerfile
@@ -36,3 +36,9 @@ RUN set -x \
        python3-pip python3-venv python3-setuptools libdbus-glib-1-dev \
        uuid-runtime libgirepository1.0-dev \
     && : # aids diffs
+
+COPY requirements_nogrpc.txt /requirements.txt
+
+RUN set -x \
+    && pip3 install -r requirements.txt \
+    && : # aids diffs

--- a/integrations/docker/images/chip-build-cirque/requirements_nogrpc.txt
+++ b/integrations/docker/images/chip-build-cirque/requirements_nogrpc.txt
@@ -1,0 +1,8 @@
+cmd2
+docker >= 4.1.0
+flask >= 1.1.0
+pycodestyle >= 2.5.0
+pylint == 2.4
+pyroute2 >= 0.5.7
+six >= 1.12
+toml

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -81,7 +81,6 @@ function cirquetest_bootstrap() {
     pip3 install pycodestyle==2.5.0 wheel
     make NO_GRPC=1 install -j
     ./dependency_modules.sh
-    pip3 install -r requirements_nogrpc.txt
 
     # Call activate here so the later tests can be faster
     # set -e will cause error if activate.sh is sourced twice
@@ -108,7 +107,10 @@ function cirquetest_run_test() {
     if [ "x$CLEANUP_DOCKER_FOR_CI" = "x1" ]; then
         echo "Do docker container and network prune"
         # TODO: Filter cirque containers
-        docker ps -aq | xargs docker stop >/dev/null 2>&1
+        IN_DOCKER=`cat /proc/1/cgroup | grep docker`
+        if [ -z $IN_DOCKER ]; then
+            docker ps -aq | xargs docker stop >/dev/null 2>&1
+        fi
         docker container prune -f >/dev/null 2>&1
         docker network prune -f >/dev/null 2>&1
     fi


### PR DESCRIPTION
1. rebuild connectedhomeip/chip-build-cirque   0.4.9 image
2. ./integrations/docker/images/chip-build-cirque/run.sh ./scripts/tests/cirque_tests.sh bootstrap
3. ./integrations/docker/images/chip-build-cirque/run.sh --privileged --env LOG_DIR=/tmp/cirque_test_output --env CLEANUP_DOCKER_FOR_CI=1 --volume /dev/pts:/dev/pts --volume /tmp/cirque_test_output:/tmp/cirque_test_output -- scripts/tests/cirque_tests.sh run_all_tests
![Screen Shot 2020-10-02 at 2 39 28 PM](https://user-images.githubusercontent.com/8865458/94967876-2c178100-04bd-11eb-8451-c3ed3a88f596.png)
